### PR TITLE
Transform into a compatible portage overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-#Gentoo Ebuild for mariadb-maxscale
+#Gentoo Portage Overlay for mariadb-maxscale

--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo

--- a/profiles/repo_name
+++ b/profiles/repo_name
@@ -1,0 +1,1 @@
+mariadb-maxscale


### PR DESCRIPTION
This small set of changes would allow your github repo to be used directly as a portage repo in repos.conf. This could make it useful and easier for others to sync on your ebuilds! :)